### PR TITLE
fix: correct error type on timeout and prevent silent message loss on macOS

### DIFF
--- a/ipmb/src/bus_controller.rs
+++ b/ipmb/src/bus_controller.rs
@@ -21,7 +21,6 @@ pub struct BusController {
     sender: Sender<EncodedMessage>,
     endpoints: Vec<Endpoint>,
     message_buffer: Vec<(Instant, EncodedMessage)>,
-    message_buffer_swap: Vec<(Instant, EncodedMessage)>,
     io_hub: IoHub,
     last_detect_reachable: Instant,
 }
@@ -41,7 +40,6 @@ impl BusController {
             sender,
             endpoints: Default::default(),
             message_buffer: Default::default(),
-            message_buffer_swap: Default::default(),
             io_hub,
             last_detect_reachable: Instant::now(),
         }
@@ -81,13 +79,10 @@ impl BusController {
                         let (remain, _) = self.handle_message(msg);
                         if let Some(remain) = remain {
                             if expire > now {
-                                self.message_buffer_swap.push((expire, remain));
+                                self.message_buffer.push((expire, remain));
                             }
                         }
                     }
-
-                    self.message_buffer = message_buffer;
-                    mem::swap(&mut self.message_buffer, &mut self.message_buffer_swap);
                 }
 
                 self.detect_reachable(now);

--- a/ipmb/src/lib.rs
+++ b/ipmb/src/lib.rs
@@ -517,7 +517,7 @@ impl Rule {
                     timeout_count += 1;
 
                     if timeout_count > 5 {
-                        return Err(JoinError::VersionMismatch(Version((0, 0, 0))));
+                        return Err(JoinError::Timeout);
                     }
 
                     wait!();

--- a/ipmb/src/platform/macos/mod.rs
+++ b/ipmb/src/platform/macos/mod.rs
@@ -410,7 +410,7 @@ impl EncodedMessage {
                         Err(Error::Disconnect)
                     } else {
                         log::error!("mach_msg failed: {r}");
-                        Ok(())
+                        Err(Error::Disconnect)
                     };
                 }
             }


### PR DESCRIPTION
## Summary

- **Fix incorrect `JoinError` type in `Rule::join`**: When the lookup times out after 5 retries, the code was returning `JoinError::VersionMismatch(Version((0, 0, 0)))` instead of `JoinError::Timeout`. This misleads callers into thinking there's a version mismatch when the real problem is a network/service timeout.
- **Fix silent message loss on macOS**: In `platform/macos/mod.rs`, when `mach_msg_send` fails with a non-retryable error and the remote is not dead, the code was returning `Ok(())` instead of `Err(Error::Disconnect)`. This causes the caller (bus controller) to believe the message was sent successfully when it was actually dropped. Now returns `Err(Error::Disconnect)` to be consistent with the Linux implementation.
- **Simplify bus controller buffer logic**: The `message_buffer_swap` field was redundant. Since `mem::take` already empties `self.message_buffer`, retained messages can be pushed directly to it without needing a swap buffer and the associated `mem::swap` call.

## Test plan

- [x] All existing unit tests pass (`cargo test` — 8 tests passed)
- [ ] Manual testing on macOS to verify `mach_msg_send` error handling
- [ ] Verify timeout error reporting in multi-process scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)